### PR TITLE
fix: missing header file

### DIFF
--- a/demos/CAN/can.c
+++ b/demos/CAN/can.c
@@ -37,6 +37,7 @@
 #include <unistd.h>
 #include <limits.h>
 #include <errno.h>
+#include <poll.h>
 
 
 #include <net/if.h>


### PR DESCRIPTION
缺少 `poll.h` 头文件，导致编译时 poll 相关变量类型、函数报错。